### PR TITLE
Add handling for the new MIME types for WOFF/WOFF2/TTF

### DIFF
--- a/src/Reader.js
+++ b/src/Reader.js
@@ -219,14 +219,17 @@ class Reader {
           this.svg();
           break;
         case 'application/x-font-ttf':
+        case 'font/ttf':
           this.config.data = util.toArrayBuffer(data);
           this.ttf();
           break;
         case 'application/font-woff':
+        case 'font/woff':
           this.config.data = data;
           this.woff();
           break;
         case 'application/font-woff2':
+        case 'font/woff2':
           this.config.data = data;
           this.woff2();
           break;


### PR DESCRIPTION
The MIME types for WOFF/WOFF2 used for detecting the format are out of date. The new standard specifies font/woff and co., and node-mime now complies with these which breaks the automatic format detection.